### PR TITLE
AVAA-9: Fix logic error when sorting nodes by variable ID

### DIFF
--- a/src/main/java/fi/csc/avaa/smear/dao/DataStructureDao.java
+++ b/src/main/java/fi/csc/avaa/smear/dao/DataStructureDao.java
@@ -150,7 +150,7 @@ public class DataStructureDao {
     };
 
     private static final Comparator<VariableNode> variableNodeComparator = (node1, node2) -> {
-        if (node1.getSortOrder() == null && node1.getSortOrder() == null) {
+        if (node1.getSortOrder() == null && node2.getSortOrder() == null) {
             return Long.valueOf(node1.getVariableId()).compareTo(Long.valueOf(node2.getVariableId()));
         } else if (node2.getSortOrder() == null) {
             return 1;


### PR DESCRIPTION
- Fix error when sorting, which caused the Smear backend to return 500